### PR TITLE
Implement service discovery using Consul

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"github.com/hashicorp/consul/api"
 )
 
 func newServiceCtx() sctx.ServiceContext {
@@ -106,6 +107,25 @@ func StartGRPCServices(serviceCtx sctx.ServiceContext) {
 
 	pb.RegisterUserServiceServer(s, composer.ComposeUserGRPCService(serviceCtx))
 	pb.RegisterAuthServiceServer(s, composer.ComposeAuthGRPCService(serviceCtx))
+
+	// Register service with Consul
+	consulConfig := api.DefaultConfig()
+	consulClient, err := api.NewClient(consulConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	serviceID := fmt.Sprintf("grpc-service-%d", configComp.GetGRPCPort())
+	serviceRegistration := &api.AgentServiceRegistration{
+		ID:      serviceID,
+		Name:    "grpc-service",
+		Port:    configComp.GetGRPCPort(),
+		Address: "localhost",
+	}
+
+	if err := consulClient.Agent().ServiceRegister(serviceRegistration); err != nil {
+		log.Fatal(err)
+	}
 
 	if err := s.Serve(lis); err != nil {
 		log.Fatalln(err)

--- a/composer/grpc_client_composer.go
+++ b/composer/grpc_client_composer.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"log"
+	"github.com/hashicorp/consul/api"
 )
 
 type authClient struct {
@@ -28,8 +29,26 @@ func (ac *authClient) IntrospectToken(ctx context.Context, accessToken string) (
 func ComposeAuthRPCClient(serviceCtx sctx.ServiceContext) *authClient {
 	configComp := serviceCtx.MustGet(common.KeyCompConf).(common.Config)
 
+	consulConfig := api.DefaultConfig()
+	consulClient, err := api.NewClient(consulConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service, _, err := consulClient.Health().Service("grpc-service", "", true, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(service) == 0 {
+		log.Fatal("No healthy service instances found")
+	}
+
+	serviceAddress := service[0].Service.Address
+	servicePort := service[0].Service.Port
+
 	opts := grpc.WithTransportCredentials(insecure.NewCredentials())
-	clientConn, err := grpc.Dial(configComp.GetGRPCServerAddress(), opts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", serviceAddress, servicePort), opts)
 
 	if err != nil {
 		log.Fatal(err)
@@ -41,8 +60,26 @@ func ComposeAuthRPCClient(serviceCtx sctx.ServiceContext) *authClient {
 func composeUserRPCClient(serviceCtx sctx.ServiceContext) pb.UserServiceClient {
 	configComp := serviceCtx.MustGet(common.KeyCompConf).(common.Config)
 
+	consulConfig := api.DefaultConfig()
+	consulClient, err := api.NewClient(consulConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service, _, err := consulClient.Health().Service("grpc-service", "", true, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(service) == 0 {
+		log.Fatal("No healthy service instances found")
+	}
+
+	serviceAddress := service[0].Service.Address
+	servicePort := service[0].Service.Port
+
 	opts := grpc.WithTransportCredentials(insecure.NewCredentials())
-	clientConn, err := grpc.Dial(configComp.GetGRPCServerAddress(), opts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", serviceAddress, servicePort), opts)
 
 	if err != nil {
 		log.Fatal(err)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       context: .
     depends_on:
       - mysql
+      - consul
     environment:
       DB_DSN: "root:@tcp(mysql:3306)/demo_db?charset=utf8mb4&parseTime=True&loc=Local"
       JWT_SECRET: "very-important-please-change-it!"
@@ -25,6 +26,12 @@ services:
       MYSQL_DATABASE: "demo_db"
     ports:
       - "3310:3306"
+    networks:
+      - intranet
+  consul:
+    image: consul:latest
+    ports:
+      - "8500:8500"
     networks:
       - intranet
 networks:


### PR DESCRIPTION
Implement service discovery using Consul for dynamic discovery and connection to services.

* **docker-compose.yaml**
  - Add Consul service configuration.
  - Update `app` service to depend on `consul` service.

* **cmd/root.go**
  - Register services with Consul in `StartGRPCServices` function.

* **composer/grpc_client_composer.go**
  - Use Consul for service discovery in `ComposeAuthRPCClient` function.
  - Use Consul for service discovery in `composeUserRPCClient` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/racho8/micro-clean-architecture-service-demo/pull/1?shareId=1bf0d86a-63b2-4b47-9ed5-f6e960a4d7a7).